### PR TITLE
feat: 면접 기록 목록 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React from "react";
+import 'C:/Users/youji/VisualStudioCode/LL_youcandoittoo_FE/youcandoittoo-FE/src/styles/theme.css';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import MainPage from "./pages/MainPage";
 import SelectInterviewPage from "./pages/SelectInterviewPage";

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import 'C:/Users/youji/VisualStudioCode/LL_youcandoittoo_FE/youcandoittoo-FE/src/styles/theme.css';
+import './styles/theme.css';
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import MainPage from "./pages/MainPage";
 import SelectInterviewPage from "./pages/SelectInterviewPage";
@@ -11,6 +11,8 @@ import { AuthProvider } from "./context/AuthContext"; // 추가
 import ResumeManagerPage from "./pages/ResumeManagerPage";
 import ResumePickPage from "./pages/ResumePickPage";
 import RecordListPage from './pages/record/RecordListPage';
+import RecordDetailPage from './pages/record/RecordDetailPage';
+import InterviewResultPage from './pages/interview/InterviewResultPage';
 
 function App() {
   return (
@@ -26,6 +28,8 @@ function App() {
           <Route path="/resume-manager" element={<ResumeManagerPage />} />
           <Route path="/resume-pick" element={<ResumePickPage />} />
           <Route path="/record" element={<RecordListPage />} />
+          <Route path="/record/:recordId" element={<RecordDetailPage />} />
+          <Route path="/interview/result/:sessionId" element={<InterviewResultPage />} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import InterviewSession from "./pages/InterviewSession";
 import { AuthProvider } from "./context/AuthContext"; // 추가
 import ResumeManagerPage from "./pages/ResumeManagerPage";
 import ResumePickPage from "./pages/ResumePickPage";
+import RecordListPage from './pages/record/RecordListPage';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
           <Route path="/interview-session" element={<InterviewSession />} />
           <Route path="/resume-manager" element={<ResumeManagerPage />} />
           <Route path="/resume-pick" element={<ResumePickPage />} />
+          <Route path="/record" element={<RecordListPage />} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,0 +1,7 @@
+.footer {
+  width: 100%;
+  margin-top: 40px;
+  text-align: center;
+  font-size: var(--font-size-caption); 
+  color: var(--color-text-muted); 
+}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './Footer.css'; 
+
+function Footer() {
+  return (
+    <footer className="footer">
+      © 2025 야 너도 할 수 있어_AI면접 프로그램 | Designed by Soonchunhyang Univ.
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/pages/InterviewSession.css
+++ b/src/pages/InterviewSession.css
@@ -341,3 +341,24 @@
 .chat-toggle-button:hover {
   background-color: #e0d8ff;
 }
+
+/* 결과 확인용 임시 코드 추가 */
+.header-buttons {
+    display: flex;
+    gap: 12px; 
+}
+
+.result-btn {
+    background-color: var(--color-brand);
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.2s;
+}
+
+.result-btn:hover {
+    background-color: #352fdd; 
+}

--- a/src/pages/InterviewSession.js
+++ b/src/pages/InterviewSession.js
@@ -140,6 +140,12 @@ function InterviewSession() {
     navigate("/select");
   };
 
+  /* 결과 확인용 임시 함수 */
+  const handleShowResult = () => {
+    const sessionId = '123'; // 예시 ID
+    navigate(`/interview/result/${sessionId}`);
+  };
+
   const handleDragStart = (e) => {
     if (resizingRef.current) return;
 
@@ -215,14 +221,24 @@ function InterviewSession() {
                     {formatTime(timeElapsed)}
                   </span>
                 </div>
-                <div>
+                {/* 결과 확인용 임시 버튼 추가 */}
+                <div className="header-buttons">
+                  <button className="exit-button" onClick={() => setExitConfirmVisible(true)}>
+                    Exit
+                  </button>
+                  <button className="result-btn" onClick={handleShowResult}>
+                    결과확인
+                  </button>
+                </div>
+                { /* 본래 코드__결과 확인용 임시 버튼 없음*/}
+                {/* <div>
                   <button
                     className="exit-button"
                     onClick={() => setExitConfirmVisible(true)}
                   >
                     Exit
                   </button>
-                </div>
+                </div> */}
               </div>
 
               <hr className="hero-divider" />

--- a/src/pages/interview/InterviewResultPage.css
+++ b/src/pages/interview/InterviewResultPage.css
@@ -1,0 +1,33 @@
+.result-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 24px;
+}
+
+.result-card {
+    background-color: var(--color-bg-surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border-subtle);
+    padding: 0px 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+.result-card h3 {
+    font-size: var(--font-size-subtitle);
+    font-weight: var(--font-weight-regular);
+    color: var(--color-text-primary);
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.large-card {
+    grid-column: span 3;
+    min-height: 300px;
+}
+
+.small-card {
+    grid-column: span 2;
+    min-height: 250px;
+}

--- a/src/pages/interview/InterviewResultPage.js
+++ b/src/pages/interview/InterviewResultPage.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import '../CommonStyles.css';
+import './InterviewResultPage.css';
+
+import Header from '../../components/Header';
+import ParticleBackground from '../../components/ParticleBackground';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+import Footer from '../../components/Footer';
+
+function ResultCard({ title, className, children }) {
+    return (
+        <div className={`result-card ${className || ''}`}>
+            <h3>{title}</h3>
+            <div className="card-content">
+                {/* 추후 분석 내용 추가 */}
+                {children}
+            </div>
+        </div>
+    );
+}
+
+function InterviewResultPage() {
+    const { user, logout } = useAuth();
+    const { sessionId } = useParams();
+
+    return (
+        <>
+            <ProtectedRoute />
+            <ParticleBackground />
+            <div className="interview-page-wrapper">
+                <div className="bar-background"></div>
+                <div className="content-wrapper">
+                    <div className="custom-card">
+                        <Header user={user} logout={logout} />
+                        <div className="record-title-bar">
+                            <h2>AI 면접 평가 (Session ID: {sessionId})</h2>
+                        </div>
+
+                        <div className="result-grid">
+                            <ResultCard title="답변 내용 분석" className="large-card" >
+                                <p>추후 답변 내용 분석에 대한 설명 추가</p>
+                            </ResultCard>
+                            <ResultCard title="비언어적 요소 분석" className="large-card" >
+                                <p>추후 행동 분석에 대한 설명 추가</p>
+                            </ResultCard>
+                            <ResultCard title="강점 및 개선요소" className="small-card" >
+                                <p>추후 답변 내용 중 강점과 개선요소에 대한 설명 추가</p>
+                            </ResultCard>
+                            <ResultCard title="그래프 분석" className="small-card" >
+                                <p>추후 답변 내용에 대한 그래프 분석 내용 추가</p>
+                            </ResultCard>
+                            <ResultCard title="성장 기록" className="small-card" >
+                                <p>추후 성장 과정에 대한 그래프? 분석 내용 추가</p>
+                            </ResultCard>
+                        </div>
+                    </div>
+                    <Footer />
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default InterviewResultPage;

--- a/src/pages/record/RecordDetailPage.css
+++ b/src/pages/record/RecordDetailPage.css
@@ -1,0 +1,68 @@
+.record-info-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    background-color: var(--color-bg-accent);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-subtitle);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.detail-grid {
+    display: grid;
+    grid-template-columns: 2fr 1.5fr;
+    gap: 24px; 
+    margin-top: 24px;
+}
+
+.right-card-column {
+    display: flex;
+    flex-direction: column;
+    gap: 24px; 
+}
+
+/* 전체 카드 기본 스타일 */
+.content-card,
+.analysis-card {
+    background-color: var(--color-bg-surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border-subtle);
+    padding: 0px 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+/* 전체 카드의 제목 스타일 */
+.content-card h3,
+.analysis-card h3 {
+    font-size: var(--font-size-subtitle);
+    font-weight: var(--font-weight-regular);
+    color: var(--color-text-primary);
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid var(--color-border-subtle);
+}
+
+/* 카드 내용 스타일 */
+.card-content {
+    flex-grow: 1; 
+    overflow-y: auto;
+    padding-bottom: 20px;
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-regular);
+}
+
+/* 스크롤바 스타일 */
+.card-content::-webkit-scrollbar {
+  width: 8px;
+}
+.card-content::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 8px;
+}
+.card-content::-webkit-scrollbar-thumb {
+  background: rgba(65, 60, 220, 0.4);
+  border-radius: 8px;
+}

--- a/src/pages/record/RecordDetailPage.js
+++ b/src/pages/record/RecordDetailPage.js
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import './RecordDetailPage.css';
+import '../CommonStyles.css';
+
+import Header from '../../components/Header';
+import ParticleBackground from '../../components/ParticleBackground';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+import Footer from '../../components/Footer';
+
+//임시 데이터 사용
+const mockRecords = [
+    { id: 1, title: "LG면접 연습(1)", company: "LG화학", date: "25-06-28", time: "10:45" },
+    { id: 2, title: "삼성전자 최종면접 대비", company: "삼성전자", date: "25-06-27", time: "15:20" },
+    { id: 3, title: "카카오 신입 공채 대비", company: "카카오", date: "25-06-25", time: "18:00" },
+];
+
+function RecordDetailPage() {
+    const { user, logout } = useAuth();
+    const { recordId } = useParams(); 
+    const [record, setRecord] = useState(null);
+
+    useEffect(() => {
+        const currentRecord = mockRecords.find(r => r.id === parseInt(recordId));
+        setRecord(currentRecord);
+    }, [recordId]);
+
+    if (!record) {
+        return <div>기록을 불러오는 중...</div>;
+    }
+
+    return (
+        <>
+            <ProtectedRoute />
+            <ParticleBackground />
+            <div className="interview-page-wrapper">
+                <div className="bar-background"></div>
+                <div className="content-wrapper">
+                    <div className="custom-card">
+                        <Header user={user} logout={logout} />
+                        <div className="record-title-bar">
+                            <h2>면접 기록</h2>
+                        </div>
+                        
+                        <div className="record-info-bar">
+                            <span>{record.title}</span>
+                            <span>{record.date} {record.time}</span>
+                        </div>
+
+                        <div className="detail-grid">
+                            <div className="content-card">
+                                <h3>질문&답변 내용</h3>
+                                <div className="card-content">
+                                    {/* 추후 질문 답변 내용 추가 */}
+                                    답변 내용 예시 작성 부분
+                                </div>
+                            </div>
+                            <div className="right-card-column">
+                                <div className="answer analysis-card">
+                                    <h3>답변 내용 분석</h3>
+                                    <div className="card-content">
+                                        {/* 추후 답변 분석 내용 추가 */}
+                                        답변 내용 예시2
+                                    </div>
+                                </div>
+                                <div className="nonlanguage analysis-card">
+                                    <h3>비언어적 요소 분석</h3>
+                                    <div className="card-content">
+                                        {/* 추후 비언어적 요소 분석 내용 추가 */}
+                                        답변 내용 예시3
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                    <Footer />
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default RecordDetailPage;

--- a/src/pages/record/RecordListPage.css
+++ b/src/pages/record/RecordListPage.css
@@ -1,9 +1,4 @@
 /* 컨테이너 */
-.interview-page-wrapper {
-  min-height: 100vh;
-  background: var(--color-brand);
-}
-
 .bar-background {
   height: 80px;
   background: linear-gradient(
@@ -26,11 +21,6 @@
   align-items: center;
   margin-bottom: 10px;
 }
-.record-title-bar h1 {
-  font-size: var(--font-size-title);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-}
 
 /* 리스트 컨테이너 */
 .record-list-container {
@@ -44,16 +34,18 @@
 /* 리스트 */
 .record-list-header {
   display: grid;
-  grid-template-columns: 2fr 1.5fr 1.5fr 2fr 1fr;
+  grid-template-columns: 1.7fr 1.5fr 1.8fr 2fr 1fr 5px;
   align-items: center;
-  padding: 18px var(--spacing-sm);
+  padding: 10px 80px; 
+  background: var(--color-bg-surface);
   color: var(--color-text-secondary);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-body);
   font-weight: var(--font-weight-semibold);
-  border-top: 1px solid var(--color-border-default);
-  border-bottom: 1px solid var(--color-border-default);
-}
 
+
+  border-top: 2px solid var(--color-border-default);
+  border-bottom: 2px solid var(--color-border-default);
+}
 
 .record-list {
   max-height: 60vh;
@@ -84,18 +76,17 @@
   grid-template-columns: 2fr 1.5fr 1.5fr 2fr 1fr 40px;
   align-items: center;
   gap: 6px;
-  padding: 20px 18px;
-  margin: 10px 6px;
+  padding: 10px 40px;
+  margin: 10px 10px;
   border-radius: var(--radius-md);
   background-color: var(--color-bg-accent);
   color: var(--color-text-primary);
-  font-size: var(--font-size-body);
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-regular);
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   border: 1px solid rgba(65, 60, 220, 0.18);
-  transition: transform 0.06s ease, background-color 0.2s ease,
-    box-shadow 0.2s ease;
+  transition: transform 0.06s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .record-item:hover {
@@ -108,6 +99,11 @@
   font-size: var(--font-size-title);
   color: var(--color-text-secondary);
   text-align: center;
+}
+
+.record-list-header > span:last-child,
+.record-item > div:last-child {
+  text-align: right;
 }
 
 /* 반응형 */

--- a/src/pages/record/RecordListPage.css
+++ b/src/pages/record/RecordListPage.css
@@ -1,0 +1,126 @@
+/* 컨테이너 */
+.interview-page-wrapper {
+  min-height: 100vh;
+  background: var(--color-brand);
+}
+
+.bar-background {
+  height: 80px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.15),
+    rgba(255, 255, 255, 0)
+  );
+}
+
+.content-wrapper {
+  position: relative;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 20px 28px;
+}
+
+/* 타이틀 */
+.record-title-bar {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.record-title-bar h1 {
+  font-size: var(--font-size-title);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+/* 리스트 컨테이너 */
+.record-list-container {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-surface);
+  overflow: hidden;
+}
+
+/* 리스트 */
+.record-list-header {
+  display: grid;
+  grid-template-columns: 2fr 1.5fr 1.5fr 2fr 1fr;
+  align-items: center;
+  padding: 18px var(--spacing-sm);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  border-top: 1px solid var(--color-border-default);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+
+.record-list {
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 10px;
+}
+
+/* 스크롤바 스타일 */
+.record-list::-webkit-scrollbar {
+  width: 10px;
+}
+.record-list::-webkit-scrollbar-track {
+  background: rgba(65, 60, 220, 0.15);
+  border-radius: 8px;
+}
+.record-list::-webkit-scrollbar-thumb {
+  background: rgba(65, 60, 220, 0.55);
+  border-radius: 8px;
+}
+.record-list {
+  scrollbar-color: rgba(65, 60, 220, 0.55) rgba(65, 60, 220, 0.15);
+  scrollbar-width: thin;
+}
+
+/* 리스트 박스 */
+.record-item {
+  display: grid;
+  grid-template-columns: 2fr 1.5fr 1.5fr 2fr 1fr 40px;
+  align-items: center;
+  gap: 6px;
+  padding: 20px 18px;
+  margin: 10px 6px;
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-accent);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-body);
+  font-weight: var(--font-weight-regular);
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(65, 60, 220, 0.18);
+  transition: transform 0.06s ease, background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.record-item:hover {
+  background-color: rgba(65, 60, 220, 0.25);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+  transform: translateY(-1px);
+}
+
+.record-item .arrow {
+  font-size: var(--font-size-title);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+/* 반응형 */
+@media (max-width: 1024px) {
+  .record-list-header,
+  .record-item {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 6px;
+  }
+  .record-item {
+    padding: 12px;
+  }
+  .record-item .arrow {
+    justify-self: end;
+  }
+}

--- a/src/pages/record/RecordListPage.js
+++ b/src/pages/record/RecordListPage.js
@@ -61,7 +61,7 @@ function RecordListPage() {
 
             {/* 페이지 타이틀 */}
             <div className="record-title-bar">
-              <h1>면접 기록</h1>
+              <h2>면접 기록</h2>
             </div>
 
             <div className="record-list-container">

--- a/src/pages/record/RecordListPage.js
+++ b/src/pages/record/RecordListPage.js
@@ -1,0 +1,105 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import "../CommonStyles.css";
+import "./RecordListPage.css";
+
+import Header from "../../components/Header";
+import ParticleBackground from "../../components/ParticleBackground";
+import ProtectedRoute from "../../components/ProtectedRoute";
+import { useAuth } from "../../context/AuthContext";
+import Footer from "../../components/Footer";
+
+// 임시 데이터
+const mockRecords = [
+  {
+    id: 1,
+    title: "LG면접 연습(1)",
+    company: "LG화학",
+    position: "데이터 엔지니어",
+    resume: "LG화학_신입지원서.pdf",
+    date: "25-06-28",
+    time: "10:45",
+  },
+  {
+    id: 2,
+    title: "삼성전자 최종면접 대비",
+    company: "삼성전자",
+    position: "AI 연구원",
+    resume: "삼성전자_포트폴리오_최종.pdf",
+    date: "25-06-27",
+    time: "15:20",
+  },
+  {
+    id: 3,
+    title: "카카오 신입 공채 대비",
+    company: "카카오",
+    position: "프론트엔드 개발자",
+    resume: "카카오_개발자_이력서.pdf",
+    date: "25-06-25",
+    time: "18:00",
+  },
+];
+
+function RecordListPage() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleRecordClick = (recordId) => {
+    navigate(`/record/${recordId}`);
+  };
+
+  return (
+    <>
+      <ProtectedRoute />
+      <ParticleBackground />
+
+      <div className="interview-page-wrapper">
+        <div className="bar-background"></div>
+        <div className="content-wrapper">
+          <div className="custom-card">
+            <Header user={user} logout={logout} />
+
+            {/* 페이지 타이틀 */}
+            <div className="record-title-bar">
+              <h1>면접 기록</h1>
+            </div>
+
+            <div className="record-list-container">
+              {/* 필터 및 정렬 바 */}
+              <div className="record-list-header">
+                <span className="col-title">제목</span>
+                <span className="col-company">지원 기업명</span>
+                <span className="col-position">지원 직무/직무명</span>
+                <span className="col-resume">자소서 제목</span>
+                <span className="col-date">날짜/시간</span>
+                <span className="col-arrow"></span>
+              </div>
+
+              {/* 면접 기록 리스트 */}
+              <div className="record-list">
+                {mockRecords.map((record) => (
+                  <div
+                    className="record-item"
+                    key={record.id}
+                    onClick={() => handleRecordClick(record.id)}
+                  >
+                    <div className="col-title">{record.title}</div>
+                    <div className="col-company">{record.company}</div>
+                    <div className="col-position">{record.position}</div>
+                    <div className="col-resume">{record.resume}</div>
+                    <div className="col-date">
+                      {record.date} {record.time}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <Footer />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default RecordListPage;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,36 @@
+:root {
+  /*Color System*/
+  --color-brand: #413CDC;             /* 메인 포인트 (하이라이트, 버튼, 탭 활성) */
+  --color-text-primary: #222222;      /* 본문/기본 텍스트 */
+  --color-text-secondary: #979797;    /* 보조 텍스트 (비활성 탭 등) */
+  --color-text-muted: rgba(0,0,0,.5); /* 푸터/보조 설명 텍스트 */
+
+  --color-bg-surface: #FFFFFF;        /* 카드, 메인 박스 배경 */
+  --color-bg-accent: rgba(65,60,220,.2); /* 연보라 강조 영역 (배지/리스트 강조행) */
+
+  --color-border-default: #D9D9D9;        /* 기본 경계선 */
+  --color-border-subtle: rgba(217,217,217,.6); /* 옅은 구분선 */
+
+  --color-accent-danger: #BF6161;     /* 프로필 원 배경 (빨강) */
+
+  /*Typography*/
+  --font-family-base: 'Inter', sans-serif;
+
+  --font-size-display: 30px;   /* 상단 탭 메뉴 등 가장 큰 제목 */
+  --font-size-title: 20px;     /* 섹션/카드 제목 */
+  --font-size-subtitle: 18px;  /* 라벨/소제목 */
+  --font-size-body: 16px;      /* 일반 본문 */
+  --font-size-caption: 14px;   /* 푸터, 설명, 부가 텍스트 */
+
+  --font-weight-regular: 500;  /* 본문 */
+  --font-weight-semibold: 600; /* 제목, 라벨 (주로 사용) */
+
+  /*Elevation, Radius*/
+  --elevation-card: 0 4px 6px rgba(0,0,0,.25);             /* 카드/작은 박스 */
+  --elevation-surface: 0 8px 30px 25px rgba(148,148,148,.25); /* 메인 컨테이너 */
+
+  --radius-sm: 10px;      /* 작은 버튼/배지 */
+  --radius-md: 14px;      /* 카드 */
+  --radius-lg: 18px;      /* 메인 박스 */
+  --radius-round: 9999px; /* 원형 배지 */
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,7 +6,7 @@
   --color-text-muted: rgba(0,0,0,.5); /* 푸터/보조 설명 텍스트 */
 
   --color-bg-surface: #FFFFFF;        /* 카드, 메인 박스 배경 */
-  --color-bg-accent: rgba(65,60,220,.2); /* 연보라 강조 영역 (배지/리스트 강조행) */
+  --color-bg-accent: rgba(65, 60, 220, 0.11); /* 연보라 강조 영역 (배지/리스트 강조행) */
 
   --color-border-default: #D9D9D9;        /* 기본 경계선 */
   --color-border-subtle: rgba(217,217,217,.6); /* 옅은 구분선 */
@@ -20,10 +20,10 @@
   --font-size-title: 20px;     /* 섹션/카드 제목 */
   --font-size-subtitle: 18px;  /* 라벨/소제목 */
   --font-size-body: 16px;      /* 일반 본문 */
-  --font-size-caption: 14px;   /* 푸터, 설명, 부가 텍스트 */
+  --font-size-caption: 14.4px;   /* 푸터, 설명, 부가 텍스트 */
 
-  --font-weight-regular: 500;  /* 본문 */
-  --font-weight-semibold: 600; /* 제목, 라벨 (주로 사용) */
+  --font-weight-regular: 400;  /* 본문 */
+  --font-weight-semibold: 500; /* 제목, 라벨 (주로 사용) */
 
   /*Elevation, Radius*/
   --elevation-card: 0 4px 6px rgba(0,0,0,.25);             /* 카드/작은 박스 */


### PR DESCRIPTION
[제작 내용]
1. 면접 기록 목록 페이지 제작 및 연동 ( /pages/record/RecordListPage)
2. Footer 컴포넌트 분리 ( /components/Footer)
3. 기본적인 테마 제작 (theme.css)

[참고사항]
1. 현재 페이지는 임시 데이터를 사용
2. 컨테이너 박스 크기, 세부 타이틀(e.g. 면접 기록) 등의 디자인 수정 필요
3. 면접 기록 세부내용 미구현

+)
[참고사항->2번] 디자인 수정 완료